### PR TITLE
Apply the trustStore setting when ssl is true - Fixes #1782

### DIFF
--- a/src/main/scala/gitbucket/core/util/LDAPUtil.scala
+++ b/src/main/scala/gitbucket/core/util/LDAPUtil.scala
@@ -149,7 +149,7 @@ object LDAPUtil {
     keystore: String,
     error: String
   )(f: LDAPConnection => Either[String, A]): Either[String, A] = {
-    if (tls) {
+    if (tls || ssl) {
       // Dynamically set Sun as the security provider
       Security.addProvider(getSslProvider())
 


### PR DESCRIPTION
Previously the truststore configuration option was applied only when StartTLS is called on a plain LDAP connection, however, the trust store is equally applicable to a full TLS connection (i.e. when ldap.ssl is set to true).

### Before submitting a pull-request to GitBucket I have first:

- [x] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [x] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [x] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [x] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct
